### PR TITLE
Update for biblatex compatibility

### DIFF
--- a/ELE/ele.bbx
+++ b/ELE/ele.bbx
@@ -14,7 +14,7 @@
     maxcitenames = 2     ,
     mincitenames = 1     ,
     maxbibnames  = 7     ,
-	minbibnames  = 6     ,
+    minbibnames  = 6     ,
     url          = false ,
     dashed       = false ,
     sorting      = nyt

--- a/ELE/ele.bbx
+++ b/ELE/ele.bbx
@@ -43,12 +43,30 @@
 %% The initials are separated by a thin space, as per Bringhurst
 \renewcommand*{\mkbibnamefirst}[1]{{\let~\,#1}}
 
-
-\DeclareNameFormat{default}{%
-  \renewcommand*{\multinamedelim}{\addsemicolon\addspace}%
-  \usebibmacro{name:last-first}{#1}{#4}{#5}{#7}%
-  \usebibmacro{name:andothers}%
-}
+%% Modify the name format
+% See http://www.texdev.net/2016/03/13/biblatex-a-new-syntax-for-declarenameformat/
+\@ifpackageloaded{biblatex_legacy}
+  {
+    % Original syntax for BibTeX model
+    \DeclareNameFormat{default}{%
+      \renewcommand*{\multinamedelim}{\addsemicolon\addspace}%
+      \usebibmacro{name:last-first}{#1}{#4}{#5}{#7}%
+      \usebibmacro{name:andothers}%
+    }
+  }
+  {
+   % New syntax for flexible back end
+    \DeclareNameFormat{default}{%
+      \renewcommand*{\multinamedelim}{\addsemicolon\addspace}%
+      \nameparts{#1}%
+      \usebibmacro{name:family-given}
+        {\namepartfamily}
+        {\namepartgiveni}
+        {\namepartprefix}
+        {\namepartsuffix}%
+      \usebibmacro{name:andothers}%
+    }
+  }
 
 \DeclareBibliographyDriver{article}{%
   \usebibmacro{bibindex}%

--- a/ELE/ele.bbx
+++ b/ELE/ele.bbx
@@ -41,7 +41,7 @@
 \DeclareNameAlias{sortname}{last-first}
 
 %% The initials are separated by a thin space, as per Bringhurst
-\renewcommand*{\mkbibnamefirst}[1]{{\let~\,#1}}
+\renewcommand*{\mkbibnamegiven}[1]{{\let~\,#1}}
 
 %% Modify the name format
 % See http://www.texdev.net/2016/03/13/biblatex-a-new-syntax-for-declarenameformat/

--- a/ELE/ele.bbx
+++ b/ELE/ele.bbx
@@ -9,7 +9,7 @@
   {
     doi          = false , 
     eprint       = false ,
-    firstinits   = true  ,
+    giveninits   = true  ,
     isbn         = false ,
     maxcitenames = 2     ,
     mincitenames = 1     ,


### PR DESCRIPTION
- [x] Syntax change for `\DeclareNameFormat`. All credit goes to @josephwright for detailing the fix [here](http://www.texdev.net/2016/03/13/biblatex-a-new-syntax-for-declarenameformat/)
- [x] Change `firstinits` for `giveninits`
- [x] Change `\mkbibnamefirst` to `\mkbibnamegiven`

I will try to push more commits for the last two points later this week but you can already review the first change if you wish.

